### PR TITLE
Fix: Add Filament v4 DOM ID compatibility to FieldHelper

### DIFF
--- a/src/Helpers/FieldHelper.php
+++ b/src/Helpers/FieldHelper.php
@@ -39,7 +39,28 @@ class FieldHelper
             ->whereInstanceOf(Field::class)->keyBy(fn($field) => $field->getName());
 
         if ($flatFields->has($field)) {
-            return $flatFields->get($field)->getStatePath();
+            $fieldComponent = $flatFields->get($field);
+            $statePath = $fieldComponent->getStatePath();
+
+            // In Filament v4, the DOM id typically has 'data.' prefix but getStatePath() might not include it
+            // Try to get the actual ID if available
+            if (method_exists($fieldComponent, 'getId')) {
+                try {
+                    $id = $fieldComponent->getId();
+                    if (! empty($id)) {
+                        return $id;
+                    }
+                } catch (\Throwable $e) {
+                    // getId() might throw if container not initialized, continue to fallback
+                }
+            }
+
+            // Fallback: If statePath doesn't already have data prefix and looks like it needs one
+            if (! str_starts_with($statePath, 'data.') && ! str_contains($statePath, '.')) {
+                return 'data.' . $statePath;
+            }
+
+            return $statePath;
         }
 
         return null;


### PR DESCRIPTION
Resolves autocomplete field ID resolution issues in Filament v4 by:

- Using getId() method when available for accurate DOM ID retrieval
- Adding 'data.' prefix fallback for v4 field state paths
- Graceful error handling for uninitialized containers

This fix ensures the Map component's autocomplete functionality works correctly with Filament v4's updated DOM structure.

Tested and confirmed working in production with Events location tab.